### PR TITLE
Add a new extension point that support signed resizing #7

### DIFF
--- a/src/ppx_hardcaml.ml
+++ b/src/ppx_hardcaml.ml
@@ -52,11 +52,11 @@ let check_index_format expr =
 (*
   rules:
     1. in [%hw ...] only allow +ve constants
-    2. in [%hws ...] leading bit always represents sign
-    3. outside [%hw{s} ...] smallest bit pattern that represents constant
+    2. in [%hw.signed ...] leading bit always represents sign
+    3. outside [%hw{.signed} ...] smallest bit pattern that represents constant
 
-     | general |  %hw | %hws
------------------------------
+     | general |  %hw | %hw.signed
+----------------------------------
 -10  | 10110   |      | 10110
  -9  | 10111   |      | 10111
  -8  |  1000   |      |  1000
@@ -180,13 +180,13 @@ let mapper argv =
       (* let%hw expression *)
       | [%expr [%hw [%e? { pexp_desc = Pexp_let(Nonrecursive, bindings, nexp) } ]]] ->
         let_binding ~signed:`unsigned bindings nexp
-      | [%expr [%hws [%e? { pexp_desc = Pexp_let(Nonrecursive, bindings, nexp) } ]]] ->
+      | [%expr [%hw.signed [%e? { pexp_desc = Pexp_let(Nonrecursive, bindings, nexp) } ]]] ->
         let_binding ~signed:`signed bindings nexp
       (* [%hw ] expression *)
       | [%expr [%hw [%e? e]]] ->
         [%expr [%e expr_mapper ~signed:`unsigned 
                      { mapper with expr = expr_mapper ~signed:`unsigned } e]]
-      | [%expr [%hws [%e? e]]] ->
+      | [%expr [%hw.signed [%e? e]]] ->
         [%expr [%e expr_mapper ~signed:`signed 
                      { mapper with expr = expr_mapper ~signed:`signed } e]]
       (* Constant *)
@@ -203,7 +203,7 @@ let mapper argv =
         [%stri let [%p mapper.pat mapper var] = 
           [%e expr_mapper ~signed:`unsigned 
                 { mapper with expr = expr_mapper ~signed:`unsigned } e0]]
-      | [%stri [%%hws let [%p? var] = [%e? e0]]] ->
+      | [%stri [%%hw.signed let [%p? var] = [%e? e0]]] ->
         [%stri let [%p mapper.pat mapper var] = 
           [%e expr_mapper ~signed:`signed 
                 { mapper with expr = expr_mapper ~signed:`signed } e0]]

--- a/src/ppx_hardcaml.ml
+++ b/src/ppx_hardcaml.ml
@@ -31,11 +31,14 @@ let location_exn ~loc msg =
 
 (* Helpers *)
 
-let (++) a b =
+let (++) ~signed a b =
   let hw_a = [%expr [%e a]]
   and hw_b = [%expr [%e b]]
   in
-  [%expr uresize [%e hw_a] (max (width [%e hw_a]) (width [%e hw_b]))]
+  if signed=`unsigned then
+    [%expr uresize [%e hw_a] (max (width [%e hw_a]) (width [%e hw_b]))]
+  else
+    [%expr sresize [%e hw_a] (max (width [%e hw_a]) (width [%e hw_b]))]
 
 (* Expression mapper *)
 
@@ -46,19 +49,63 @@ let check_index_format expr =
   | Pexp_ident(_) -> ()
   | _ -> location_exn ~loc:expr.pexp_loc "Invalid signal subscript format"
 
-let const_mapper = function
+(*
+  rules:
+    1. in [%hw ...] only allow +ve constants
+    2. in [%hws ...] leading bit always represents sign
+    3. outside [%hw{s} ...] smallest bit pattern that represents constant
+
+     | general |  %hw | %hws
+-----------------------------
+-10  | 10110   |      | 10110
+ -9  | 10111   |      | 10111
+ -8  |  1000   |      |  1000
+ -7  |  1001   |      |  1001
+ -6  |  1010   |      |  1010
+ -5  |  1011   |      |  1011
+ -4  |   100   |      |   100
+ -3  |   101   |      |   101
+ -2  |    10   |      |    10
+ -1  |     1   |      |     1
+  0  |     0   |    0 |     0
+  1  |     1   |    1 |    01
+  2  |    10   |   10 |   010
+  3  |    11   |   11 |   011
+  4  |   100   |  100 |  0100
+  5  |   101   |  101 |  0101
+  6  |   110   |  110 |  0110
+  7  |   111   |  111 |  0111
+  8  |  1000   | 1000 | 01000
+  9  |  1001   | 1001 | 01001
+ 10  |  1010   | 1010 | 01010
+*)
+let consti_mapper ~loc ~signed v = 
+  let rec nbits x = match x with 0 | 1 -> 1 | x -> 1 + (nbits (x/2)) in
+  let rec sbits i = if i >= -1 then nbits (abs i) else 1 + sbits (abs (i+1)) in
+  let v = int_of_string v in
+  let nbits = 
+    match signed with
+    | `unsigned when v < 0 -> 
+      location_exn ~loc "Invalid constant format - expecting unsigned value"
+    | `signed when v > 0 -> 1 + nbits v
+    | _ when v < 0 -> sbits v
+    | _ -> nbits v
+  in
+  [%expr consti [%e int nbits] [%e int v]]
+
+let const_mapper ~signed = function
   | { pexp_desc = Pexp_constant(Pconst_integer(txt, Some('h'))) } as expr
     when String.length txt > 2 && String.sub txt ~pos:0 ~len:2 = "0b" ->
     let l = String.length txt - 2 in
     let s = String.sub txt ~pos:2 ~len:l in
     let v = { expr with pexp_desc = Pexp_constant(Pconst_string(s, None)) } in
     [%expr constb [%e v]] 
-  | { pexp_desc = Pexp_constant(Pconst_integer(txt, Some('h'))) } as expr ->
-    let v = { expr with pexp_desc = Pexp_constant(Pconst_integer(txt, None)) } in
-    [%expr consti (HardCaml.Utils.nbits [%e v]) [%e v]] 
+  | { pexp_desc = Pexp_constant(Pconst_integer(txt, Some('h'))); pexp_loc } ->
+    consti_mapper ~loc:pexp_loc ~signed txt
   | { pexp_loc } -> location_exn ~loc:pexp_loc "Invalid constant format"
 
-let expr_mapper m expr =
+let expr_mapper ~signed m expr =
+  let (++) = (++) ~signed in
   (* Check the type of the expression *)
   begin match expr with 
     (* Bitwise operators *)
@@ -68,13 +115,23 @@ let expr_mapper m expr =
     | [%expr         lnot [%e? a]] -> Some [%expr             ~:  [%e      a]]
     (* Arithmetic operators *)
     | [%expr [%e? a] +    [%e? b]] -> Some [%expr [%e a ++ b] +:  [%e b ++ a]]
-    | [%expr [%e? a] *    [%e? b]] -> Some [%expr [%e a ++ b] *:  [%e b ++ a]]
+    | [%expr [%e? a] *    [%e? b]] -> Some (if signed=`signed 
+                                            then [%expr [%e a ++ b] *+  [%e b ++ a]]
+                                            else [%expr [%e a ++ b] *:  [%e b ++ a]])
     | [%expr [%e? a] -    [%e? b]] -> Some [%expr [%e a ++ b] -:  [%e b ++ a]]
     (* Comparison operators *)
-    | [%expr [%e? a] <    [%e? b]] -> Some [%expr [%e a ++ b] <:  [%e b ++ a]]
-    | [%expr [%e? a] <=   [%e? b]] -> Some [%expr [%e a ++ b] <=: [%e b ++ a]]
-    | [%expr [%e? a] >    [%e? b]] -> Some [%expr [%e a ++ b] >:  [%e b ++ a]]
-    | [%expr [%e? a] >=   [%e? b]] -> Some [%expr [%e a ++ b] >=: [%e b ++ a]]
+    | [%expr [%e? a] <    [%e? b]] -> Some (if signed=`signed 
+                                            then [%expr [%e a ++ b] <+  [%e b ++ a]]
+                                            else [%expr [%e a ++ b] <:  [%e b ++ a]])
+    | [%expr [%e? a] <=   [%e? b]] -> Some (if signed=`signed 
+                                            then [%expr [%e a ++ b] <=+  [%e b ++ a]]
+                                            else [%expr [%e a ++ b] <=:  [%e b ++ a]])
+    | [%expr [%e? a] >    [%e? b]] -> Some (if signed=`signed 
+                                            then [%expr [%e a ++ b] >+  [%e b ++ a]]
+                                            else [%expr [%e a ++ b] >:  [%e b ++ a]])
+    | [%expr [%e? a] >=   [%e? b]] -> Some (if signed=`signed 
+                                            then [%expr [%e a ++ b] >=+  [%e b ++ a]]
+                                            else [%expr [%e a ++ b] >=:  [%e b ++ a]])
     | [%expr [%e? a] ==   [%e? b]] -> Some [%expr [%e a ++ b] ==: [%e b ++ a]]
     | [%expr [%e? a] <>   [%e? b]] -> Some [%expr [%e a ++ b] <>: [%e b ++ a]]
     (* Concatenation operator *)
@@ -93,7 +150,7 @@ let expr_mapper m expr =
       Some [%expr mux2 [%e cnd] [%e e0 ++ e1] [%e e1 ++ e0]]
     (* Constant *)
     | { pexp_desc = Pexp_constant(Pconst_integer(_, Some('h'))) } ->
-      Some (const_mapper expr)
+      Some (const_mapper ~signed expr)
     (* Default *)
     | expr -> None
   end
@@ -108,24 +165,33 @@ let mapper argv =
   { default_mapper with
     (* Expression mapper *)
     expr = begin fun mapper expr ->
-      match expr with
-      (* let%hw expression *)
-      | [%expr [%hw [%e? { pexp_desc = Pexp_let(Nonrecursive, bindings, nexp) } ]]] ->
+      let let_binding ~signed bindings nexp = 
         let wb = List.map
             (fun ({ pvb_pat; pvb_expr } as binding) ->
                { binding with
                  pvb_pat = mapper.pat mapper pvb_pat;
-                 pvb_expr = expr_mapper { mapper with expr = expr_mapper } pvb_expr;
+                 pvb_expr = expr_mapper ~signed { mapper with expr = expr_mapper ~signed} pvb_expr;
                })
             bindings in
         let next = mapper.expr mapper nexp in
         { expr with pexp_desc = Pexp_let(Nonrecursive, wb, next) }
+      in
+      match expr with
+      (* let%hw expression *)
+      | [%expr [%hw [%e? { pexp_desc = Pexp_let(Nonrecursive, bindings, nexp) } ]]] ->
+        let_binding ~signed:`unsigned bindings nexp
+      | [%expr [%hws [%e? { pexp_desc = Pexp_let(Nonrecursive, bindings, nexp) } ]]] ->
+        let_binding ~signed:`signed bindings nexp
       (* [%hw ] expression *)
       | [%expr [%hw [%e? e]]] ->
-        [%expr [%e expr_mapper { mapper with expr = expr_mapper } e]]
+        [%expr [%e expr_mapper ~signed:`unsigned 
+                     { mapper with expr = expr_mapper ~signed:`unsigned } e]]
+      | [%expr [%hws [%e? e]]] ->
+        [%expr [%e expr_mapper ~signed:`signed 
+                     { mapper with expr = expr_mapper ~signed:`signed } e]]
       (* Constant *)
       | { pexp_desc = Pexp_constant(Pconst_integer(_, Some('h'))) } ->
-        const_mapper expr
+        const_mapper ~signed:`smallest expr
       (* Default mapper *)
       | _ -> default_mapper.expr mapper expr
     end;
@@ -135,7 +201,12 @@ let mapper argv =
       (* [%hw let pat = <expr>] or 'let%hw pat = <expr>' *)
       | [%stri [%%hw let [%p? var] = [%e? e0]]] ->
         [%stri let [%p mapper.pat mapper var] = 
-          [%e expr_mapper { mapper with expr = expr_mapper } e0]]
+          [%e expr_mapper ~signed:`unsigned 
+                { mapper with expr = expr_mapper ~signed:`unsigned } e0]]
+      | [%stri [%%hws let [%p? var] = [%e? e0]]] ->
+        [%stri let [%p mapper.pat mapper var] = 
+          [%e expr_mapper ~signed:`signed 
+                { mapper with expr = expr_mapper ~signed:`signed } e0]]
       (* Default mapper *)
       | _ -> default_mapper.structure_item mapper stri
     end

--- a/tests/PpxHardcamlTest.ml
+++ b/tests/PpxHardcamlTest.ml
@@ -70,21 +70,21 @@ let multi_part_binop context =
   let a, b, c = consti 2 0, consti 2 1, consti 2 2 in
   assert_equal [%hw a + b + c] (consti 2 3)
 
-let%hws signed_mul context = 
+let%hw.signed signed_mul context = 
   assert_equal ((-3h * 3h) == (-9h)) 0b1h;
   assert_equal ((2h * 3h) == 6h) vdd;
   assert_equal ((-20h * -9h) == 180h) 0b1h
 
 let signed_comparison context = 
-  [%hws assert_equal (-2h < 0h) 0b1h];
-  [%hws assert_equal (-2h < 4h) 0b1h];
-  [%hws assert_equal (-20h < -19h) 0b1h];
-  [%hws assert_equal (-19h < -20h) 0b0h];
-  [%hws assert_equal (7h > 2h) 0b1h];
-  [%hws assert_equal (7h > 7h) 0b0h];
-  [%hws assert_equal (7h >= 7h) 0b1h];
-  [%hws assert_equal (-7h == -7h) 0b1h];
-  [%hws assert_equal (-7h <> -7h) 0b0h]
+  [%hw.signed assert_equal (-2h < 0h) 0b1h];
+  [%hw.signed assert_equal (-2h < 4h) 0b1h];
+  [%hw.signed assert_equal (-20h < -19h) 0b1h];
+  [%hw.signed assert_equal (-19h < -20h) 0b0h];
+  [%hw.signed assert_equal (7h > 2h) 0b1h];
+  [%hw.signed assert_equal (7h > 7h) 0b0h];
+  [%hw.signed assert_equal (7h >= 7h) 0b1h];
+  [%hw.signed assert_equal (-7h == -7h) 0b1h];
+  [%hw.signed assert_equal (-7h <> -7h) 0b0h]
 
 (*
  * Inline functions
@@ -153,7 +153,7 @@ let%hw unsigned_immediate_const context =
   assert_equal (  9h) (constb "1001");
   assert_equal ( 10h) (constb "1010")
 
-let%hws signed_immediate_const context = 
+let%hw.signed signed_immediate_const context = 
   assert_equal (-10h) (constb "10110");
   assert_equal ( -9h) (constb "10111");
   assert_equal ( -5h) (constb "1011");

--- a/tests/PpxHardcamlTest.ml
+++ b/tests/PpxHardcamlTest.ml
@@ -70,6 +70,22 @@ let multi_part_binop context =
   let a, b, c = consti 2 0, consti 2 1, consti 2 2 in
   assert_equal [%hw a + b + c] (consti 2 3)
 
+let%hws signed_mul context = 
+  assert_equal ((-3h * 3h) == (-9h)) 0b1h;
+  assert_equal ((2h * 3h) == 6h) vdd;
+  assert_equal ((-20h * -9h) == 180h) 0b1h
+
+let signed_comparison context = 
+  [%hws assert_equal (-2h < 0h) 0b1h];
+  [%hws assert_equal (-2h < 4h) 0b1h];
+  [%hws assert_equal (-20h < -19h) 0b1h];
+  [%hws assert_equal (-19h < -20h) 0b0h];
+  [%hws assert_equal (7h > 2h) 0b1h];
+  [%hws assert_equal (7h > 7h) 0b0h];
+  [%hws assert_equal (7h >= 7h) 0b1h];
+  [%hws assert_equal (-7h == -7h) 0b1h];
+  [%hws assert_equal (-7h <> -7h) 0b0h]
+
 (*
  * Inline functions
  *)
@@ -116,7 +132,39 @@ let inline_ext_rec_let context =
 
 let nohw_immediate_const context =
   let z = 0b1010h in
-  assert_equal z (constb "1010")
+  assert_equal z (constb "1010");
+  assert_equal (-10h) (constb "10110");
+  assert_equal ( -9h) (constb "10111");
+  assert_equal ( -5h) (constb "1011");
+  assert_equal ( -2h) (constb "10");
+  assert_equal ( -1h) (constb "1");
+  assert_equal (  0h) (constb "0");
+  assert_equal (  1h) (constb "1");
+  assert_equal (  2h) (constb "10");
+  assert_equal (  5h) (constb "101");
+  assert_equal (  9h) (constb "1001");
+  assert_equal ( 10h) (constb "1010")
+
+let%hw unsigned_immediate_const context = 
+  assert_equal (  0h) (constb "0");
+  assert_equal (  1h) (constb "1");
+  assert_equal (  2h) (constb "10");
+  assert_equal (  5h) (constb "101");
+  assert_equal (  9h) (constb "1001");
+  assert_equal ( 10h) (constb "1010")
+
+let%hws signed_immediate_const context = 
+  assert_equal (-10h) (constb "10110");
+  assert_equal ( -9h) (constb "10111");
+  assert_equal ( -5h) (constb "1011");
+  assert_equal ( -2h) (constb "10");
+  assert_equal ( -1h) (constb "1");
+  assert_equal (  0h) (constb "0");
+  assert_equal (  1h) (constb "01");
+  assert_equal (  2h) (constb "010");
+  assert_equal (  5h) (constb "0101");
+  assert_equal (  9h) (constb "01001");
+  assert_equal ( 10h) (constb "01010")
 
 let%hw immediate_const context =
   let x = 1h and y = 0xdh and z = 0b1010h in
@@ -156,10 +204,14 @@ let suite = "PpxHardcamlTest" >::: [
     "signal_int_binop"        >:: signal_int_binop;
     "auto_resize_binop"       >:: auto_resize_binop;
     "multi_part_binop"        >:: multi_part_binop;
+    "signed_mul"              >:: signed_mul;
+    "signed_comparison"              >:: signed_comparison;
     "inline_function"         >:: inline_function;
     "structural_let"          >:: structural_let;
     "inline_ext_rec_let"      >:: inline_ext_rec_let;
     "nohw_immediate_const"    >:: nohw_immediate_const;
+    "unsigned_immediate_const">:: unsigned_immediate_const;
+    "signed_immediate_const"  >:: signed_immediate_const;
     "immediate_const"         >:: immediate_const;
     "binary_immediate"        >:: binary_immediate;
     "select_const_test"       >:: select_const_test;


### PR DESCRIPTION
Add support for signed arithmetic and constants.

There are some non-obvious rules regarding constants which should be documented.

1. `Global` hardware constants can now be signed (they would have raised an exception in nbits before).  The smallest bit-pattern needed to represent the value is generated.  Note that this means `1h` and `-1h` have the same bit pattern.
2. Within [%hw ...] expressions, negative values are disallowed.
3. Within [%hws ...] expressions, the MSB of the constant generated will represent the sign of the value (0 for positive, 1 for negative) which allows the use of `sresize` in the operators to implement 2s-complement signed arithmetic.